### PR TITLE
intel: Handle Wayland environment

### DIFF
--- a/src/intel/intel_driver.c
+++ b/src/intel/intel_driver.c
@@ -235,8 +235,13 @@ if(intel->x11_display) {
     intel_driver_init_shared(intel, intel->dri_ctx);
     Xfree(driver_name);
   }
-  else
-    fprintf(stderr, "X server found. dri2 connection failed! \n");
+  else {
+    /* if you run beignet under wayland environment,
+       XOpenDisplay succeeds, but VA_DRI2QueryExtension fails.
+       we fall back to using DRM render node. */
+    if(intel->x11_display) XCloseDisplay(intel->x11_display);
+    intel->x11_display = NULL;
+  }
 }
 #endif
 


### PR DESCRIPTION
When we are using Wayland, XOpenDisplay succeeds because of XWayland.
However VA_DRI2QueryExtension for that display fails, and we give up
initializing beignet on Wayland environment. This patch changes this
initialization strategy: falling back to using DRM render nodes or
DRM nodes. In the future, we should have code handling Wayland display
before starting X11 path.