### PR TITLE
GBE: let GenRegister::reg() never return uninitialized memory

### DIFF
--- a/backend/src/backend/gen_register.hpp
+++ b/backend/src/backend/gen_register.hpp
@@ -243,7 +243,12 @@ namespace gbe
     }
 
     /*! Return the IR virtual register */
-    INLINE ir::Register reg(void) const { return ir::Register(value.reg); }
+    INLINE ir::Register reg(void) const {
+      if (this->physical)
+        return ir::Register();
+      else
+        return ir::Register(value.reg);
+    }
 
     /*! For immediates or virtual register */
     union {


### PR DESCRIPTION
GenRegister::reg() is called throughout the code, not only on virtual but also on physical registers. For the latter, value.reg is not initialized and therefore reg() returns uninitialized memory, leading to undefined behavior. Make sure to always return initialized memory by returning a valid ir::Register, even for physical registers.

Fixes https://gitlab.freedesktop.org/beignet/beignet/issues/12